### PR TITLE
Update the try_model option to our images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/logs/
 *pth.tar
 *.ipynb
+**/upscaled/

--- a/ESRGAN/config.py
+++ b/ESRGAN/config.py
@@ -3,7 +3,7 @@ from PIL import Image
 import albumentations as A
 from albumentations.pytorch import ToTensorV2
 
-LOAD_MODEL = False
+LOAD_MODEL = True
 SAVE_MODEL = True
 CHECKPOINT_GEN = "gen.pth.tar"
 CHECKPOINT_DISC = "disc.pth.tar"
@@ -21,5 +21,12 @@ transform = A.Compose(
     [
      A.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
      ToTensorV2(),
+    ]
+)
+
+test_transform = A.Compose(
+    [
+        A.Normalize(mean=[0, 0, 0], std=[1, 1, 1]),
+        ToTensorV2(),
     ]
 )

--- a/ESRGAN/train.py
+++ b/ESRGAN/train.py
@@ -135,7 +135,7 @@ def main():
 
 
 if __name__ == "__main__":
-    try_model = False
+    try_model = True
 
     if try_model:
         # Will just use pretrained weights and run on images
@@ -148,7 +148,7 @@ if __name__ == "__main__":
             opt_gen,
             config.LEARNING_RATE,
         )
-        plot_examples("test_images/", gen)
+        plot_examples("data/lr/", gen)
     else:
         # This will train from scratch
         main()

--- a/ESRGAN/utils.py
+++ b/ESRGAN/utils.py
@@ -56,12 +56,17 @@ def plot_examples(low_res_folder, gen):
 
     gen.eval()
     for file in files:
-        image = Image.open("test_images/" + file)
+        image = Image.open("data/lr/" + file)
+
+        # Upscaling 1 channel to 3 channels: our images are in gray scale.
+        rgbimg = Image.new("RGB", image.size)
+        rgbimg.paste(image)
+
         with torch.no_grad():
             upscaled_img = gen(
-                config.test_transform(image=np.asarray(image))["image"]
+                config.test_transform(image=np.asarray(rgbimg))["image"]
                 .unsqueeze(0)
                 .to(config.DEVICE)
             )
-        save_image(upscaled_img, f"saved/{file}")
+        save_image(upscaled_img, f"upscaled/{file}")
     gen.train()


### PR DESCRIPTION
Our images are single channel while the original work is intended to
processes 3 channels images. Add an upscale in the utils and updated
the default path. Add the test_transform that previously removed not
included.
[Ticket: 2]